### PR TITLE
wvm: Add gcc directives to suppress compiler warnings

### DIFF
--- a/Axb.c
+++ b/Axb.c
@@ -1,6 +1,6 @@
 /*
 /////////////////////////////////////////////////////////////////////////////////
-// 
+//
 //  Solution of linear systems involved in the Levenberg - Marquardt
 //  minimization algorithm
 //  Copyright (C) 2004  Manolis Lourakis (lourakis at ics forth gr)
@@ -20,7 +20,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 */
 
-/******************************************************************************** 
+/********************************************************************************
  * LAPACK-based implementations for various linear system solvers. The same core
  * code is used with appropriate #defines to derive single and double precision
  * solver versions, see also Axb_core.c
@@ -50,7 +50,7 @@
 
 /*
 /////////////////////////////////////////////////////////////////////////////////
-// 
+//
 //  Solution of linear systems involved in the Levenberg - Marquardt
 //  minimization algorithm
 //  Copyright (C) 2004  Manolis Lourakis (lourakis at ics forth gr)
@@ -92,7 +92,7 @@
 /*
  * This function returns the solution of Ax = b
  *
- * The function employs LU decomposition followed by forward/back substitution (see 
+ * The function employs LU decomposition followed by forward/back substitution (see
  * also the LAPACK-based LU solver above)
  *
  * A is mxm, b is mx1
@@ -107,7 +107,9 @@
 int AX_EQ_B_LU(LM_REAL *A, LM_REAL *B, LM_REAL *x, int m)
 {
 __STATIC__ void *buf=NULL;
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 __STATIC__ int buf_sz=0;
+#pragma GCC diagnostic pop
 
 register int i, j, k;
 int *idx, maxi=-1, idx_sz, a_sz, work_sz, tot_sz;
@@ -125,7 +127,7 @@ LM_REAL *a, *work, max, sum, tmp;
 #else
     return 1; /* NOP */
 #endif /* LINSOLVERS_RETAIN_MEMORY */
-   
+
   /* calculate required memory size */
   idx_sz=m;
   a_sz=m*m;

--- a/lmbc.c
+++ b/lmbc.c
@@ -1,6 +1,6 @@
 /*
 /////////////////////////////////////////////////////////////////////////////////
-// 
+//
 //  Levenberg - Marquardt non-linear minimization algorithm
 //  Copyright (C) 2004-05  Manolis Lourakis (lourakis at ics forth gr)
 //  Institute of Computer Science, Foundation for Research & Technology - Hellas
@@ -19,7 +19,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 */
 
-/******************************************************************************** 
+/********************************************************************************
  * Box-constrained Levenberg-Marquardt nonlinear minimization. The same core code
  * is used with appropriate #defines to derive single and double precision versions,
  * see also lmbc_core.c
@@ -54,7 +54,7 @@
 
 /*
 /////////////////////////////////////////////////////////////////////////////////
-// 
+//
 //  Levenberg - Marquardt non-linear minimization algorithm
 //  Copyright (C) 2004-05  Manolis Lourakis (lourakis at ics forth gr)
 //  Institute of Computer Science, Foundation for Research & Technology - Hellas
@@ -308,7 +308,7 @@ register int i;
         p[i]=__MEDIAN3(lb[i], p[i], ub[i]);
 }
 
-/* 
+/*
  * This function seeks the parameter vector p that best describes the measurements
  * vector x under box constraints.
  * More precisely, given a vector function  func : R^m --> R^n with n>=m,
@@ -325,13 +325,13 @@ register int i;
  * For details, see C. Kanzow, N. Yamashita and M. Fukushima: "Levenberg-Marquardt
  * methods for constrained nonlinear equations with strong local convergence properties",
  * Journal of Computational and Applied Mathematics 172, 2004, pp. 375-397.
- * Also, see K. Madsen, H.B. Nielsen and O. Tingleff's lecture notes on 
+ * Also, see K. Madsen, H.B. Nielsen and O. Tingleff's lecture notes on
  * unconstrained Levenberg-Marquardt at http://www.imm.dtu.dk/pubdb/views/edoc_download.php/3215/pdf/imm3215.pdf
  */
 
 int LEVMAR_BC_DER(
   void (*func)(LM_REAL *p, LM_REAL *hx, int m, int n, void *adata), /* functional relation describing measurements. A p \in R^m yields a \hat{x} \in  R^n */
-  void (*jacf)(LM_REAL *p, LM_REAL *j, int m, int n, void *adata),  /* function to evaluate the Jacobian \part x / \part p */ 
+  void (*jacf)(LM_REAL *p, LM_REAL *j, int m, int n, void *adata),  /* function to evaluate the Jacobian \part x / \part p */
   LM_REAL *p,         /* I/O: initial parameter estimates. On output has the estimated solution */
   LM_REAL *x,         /* I: measurement vector. NULL implies a zero vector */
   int m,              /* I: parameter vector dimension (i.e. #unknowns) */
@@ -351,7 +351,7 @@ int LEVMAR_BC_DER(
                       * info[6]=reason for terminating: 1 - stopped by small gradient J^T e
                       *                                 2 - stopped by small Dp
                       *                                 3 - stopped by itmax
-                      *                                 4 - singular matrix. Restart from current p with increased mu 
+                      *                                 4 - singular matrix. Restart from current p with increased mu
                       *                                 5 - no further error reduction is possible. Restart with increased mu
                       *                                 6 - stopped by small ||e||_2
                       *                                 7 - stopped by invalid (i.e. NaN or Inf) "func" values. This is a user error
@@ -395,7 +395,9 @@ LM_REAL tmin=LM_CNST(1e-12), tming=LM_CNST(1e-18); /* minimum step length for LS
 const LM_REAL tini=LM_CNST(1.0); /* initial step length for LS and PG steps */
 int nLMsteps=0, nLSsteps=0, nPGsteps=0, gprevtaken=0;
 int numactive;
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 int (*linsolver)(LM_REAL *A, LM_REAL *B, LM_REAL *x, int m)=NULL;
+#pragma GCC diagnostic pop
 
   mu=jacTe_inf=t=0.0;  tmin=tmin; /* -Wall */
 
@@ -455,7 +457,7 @@ int (*linsolver)(LM_REAL *A, LM_REAL *B, LM_REAL *x, int m)=NULL;
   fstate.x=x;
   fstate.adata=adata;
   fstate.nfev=&nfev;
-  
+
   /* see if starting point is within the feasile set */
   for(i=0; i<m; ++i)
     pDp[i]=p[i];
@@ -512,7 +514,7 @@ int (*linsolver)(LM_REAL *A, LM_REAL *B, LM_REAL *x, int m)=NULL;
        * performance problem.
        *
        * Note that the non-blocking algorithm is faster on small
-       * problems since in this case it avoids the overheads of blocking. 
+       * problems since in this case it avoids the overheads of blocking.
        */
       register int l, im;
       register LM_REAL alpha, *jaclm;
@@ -558,9 +560,9 @@ int (*linsolver)(LM_REAL *A, LM_REAL *B, LM_REAL *x, int m)=NULL;
     }
 
 	  /* Compute ||J^T e||_inf and ||p||^2. Note that ||J^T e||_inf
-     * is computed for free (i.e. inactive) variables only. 
+     * is computed for free (i.e. inactive) variables only.
      * At a local minimum, if p[i]==ub[i] then g[i]>0;
-     * if p[i]==lb[i] g[i]<0; otherwise g[i]=0 
+     * if p[i]==lb[i] g[i]<0; otherwise g[i]=0
      */
     for(i=j=numactive=0, p_L2=jacTe_inf=0.0; i<m; ++i){
       if(ub && p[i]==ub[i]){ ++numactive; if(jacTe[i]>0.0) ++j; }
@@ -595,7 +597,7 @@ if(!(k%100)){
           if(diag_jacTjac[i]>tmp) tmp=diag_jacTjac[i]; /* find max diagonal element */
         mu=tau*tmp;
       }
-      else 
+      else
         mu=LM_CNST(0.5)*tau*p_eL2; /* use Kanzow's starting mu */
     }
 
@@ -756,7 +758,7 @@ if(!(k%100)){
         gprevtaken=0;
 
         /* NOTE: new estimate for p is in pDp, associated error in hx and its norm in pDp_eL2.
-         * These values are used below to update their corresponding variables 
+         * These values are used below to update their corresponding variables
          */
       }
       else{
@@ -861,7 +863,7 @@ breaknested: /* NOTE: this point is also reached via an explicit goto! */
   if(covar){
     LEVMAR_COVAR(jacTjac, covar, p_eL2, m, n);
   }
-                                                               
+
   if(freework) free(work);
 
 #ifdef LINSOLVERS_RETAIN_MEMORY
@@ -908,7 +910,7 @@ struct LMBC_DIF_DATA *dta=(struct LMBC_DIF_DATA *)data;
 }
 
 
-/* No Jacobian version of the LEVMAR_BC_DER() function above: the Jacobian is approximated with 
+/* No Jacobian version of the LEVMAR_BC_DER() function above: the Jacobian is approximated with
  * the aid of finite differences (forward or central, see the comment for the opts argument)
  * Ideally, this function should be implemented with a secant approach. Currently, it just calls
  * LEVMAR_BC_DER()
@@ -926,7 +928,7 @@ int LEVMAR_BC_DIF(
                        * scale factor for initial \mu, stopping thresholds for ||J^T e||_inf, ||Dp||_2 and ||e||_2 and
                        * the step used in difference approximation to the Jacobian. Set to NULL for defaults to be used.
                        * If \delta<0, the Jacobian is approximated with central differences which are more accurate
-                       * (but slower!) compared to the forward differences employed by default. 
+                       * (but slower!) compared to the forward differences employed by default.
                        */
   LM_REAL info[LM_INFO_SZ],
 					           /* O: information regarding the minimization. Set to NULL if don't care
@@ -936,7 +938,7 @@ int LEVMAR_BC_DIF(
                       * info[6]=reason for terminating: 1 - stopped by small gradient J^T e
                       *                                 2 - stopped by small Dp
                       *                                 3 - stopped by itmax
-                      *                                 4 - singular matrix. Restart from current p with increased mu 
+                      *                                 4 - singular matrix. Restart from current p with increased mu
                       *                                 5 - no further error reduction is possible. Restart with increased mu
                       *                                 6 - stopped by small ||e||_2
                       *                                 7 - stopped by invalid (i.e. NaN or Inf) "func" values. This is a user error

--- a/misc.c
+++ b/misc.c
@@ -473,7 +473,9 @@ int info, rank, worksz, *iwork, iworksz;
 static int LEVMAR_LUINVERSE(LM_REAL *A, LM_REAL *B, int m)
 {
 void *buf=NULL;
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 int buf_sz=0;
+#pragma GCC diagnostic pop
 
 register int i, j, k, l;
 int *idx, maxi=-1, idx_sz, a_sz, x_sz, work_sz, tot_sz;
@@ -798,6 +800,7 @@ register LM_REAL sum0=0.0, sum1=0.0, sum2=0.0, sum3=0.0;
        * us to finish off the appropriate number of items.
        */
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
       switch(n - i){
         case 7 : e[i]=x[i]-y[i]; sum0+=e[i]*e[i]; ++i;
         case 6 : e[i]=x[i]-y[i]; sum1+=e[i]*e[i]; ++i;
@@ -807,6 +810,8 @@ register LM_REAL sum0=0.0, sum1=0.0, sum2=0.0, sum3=0.0;
         case 2 : e[i]=x[i]-y[i]; sum1+=e[i]*e[i]; ++i;
       case 1 : e[i]=x[i]-y[i]; sum2+=e[i]*e[i]; /*++i;*/
       }
+#pragma GCC diagnostic pop
+
     }
   }
   else{ /* x==0 */
@@ -833,6 +838,7 @@ register LM_REAL sum0=0.0, sum1=0.0, sum2=0.0, sum3=0.0;
        * us to finish off the appropriate number of items.
        */
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
       switch(n - i){
         case 7 : e[i]=-y[i]; sum0+=e[i]*e[i]; ++i;
         case 6 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i;
@@ -842,6 +848,8 @@ register LM_REAL sum0=0.0, sum1=0.0, sum2=0.0, sum3=0.0;
         case 2 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i;
       case 1 : e[i]=-y[i]; sum2+=e[i]*e[i]; /*++i;*/
       }
+#pragma GCC diagnostic pop
+
     }
   }
 

--- a/wvmOpt.c
+++ b/wvmOpt.c
@@ -1,16 +1,16 @@
 /*
-                                                                  
-  File name: 
+
+  File name:
     wvmOpt.c
 
-  Description:  
+  Description:
 
   Functions:
     wvmEst
     wvmOpt
     wvmOptMulti
 
- History: 
+ History:
    $Log$
    Revision 1.7  2016/01/26 23:40:05  ryanb
    return iters from wvmOptMulti
@@ -76,7 +76,8 @@ typedef struct data {
 /* The function to be minimized returns the theoretical result in an
    array so is a simplified layer on top of wvmEst */
 
-static void atmEst_f ( double * p, double *x, int m, int n, void *data )
+static void atmEst_f ( double * p, double *x, int m __attribute__((unused)),
+                       int n, void *data )
 {
   double AEFF[3];
   double TBRI[3];
@@ -140,18 +141,18 @@ static void atmEst_f ( double * p, double *x, int m, int n, void *data )
    Calculate the best fitting water, broadband opacity and effective
    temperature.
 
-      
+
  *  Language:
       C
 
  *  Call:
- 
-      wvmOpt(float aMass, float tAmb, const float tSky[], float * waterDens, 
+
+      wvmOpt(float aMass, float tAmb, const float tSky[], float * waterDens,
              float * tau0, float * tWat);
 
  *  Parameters:
       ("<" input, "!" modified, "W" workspace, ">" output)
-      (<) aMass      The air Mass 
+      (<) aMass      The air Mass
       (<) tAmb       The ambient temperature
       (<) tSky       The sky temperature of each receiver (3 data points)
       (>) waterDens  The line-of sight water density in mm
@@ -162,11 +163,11 @@ static void atmEst_f ( double * p, double *x, int m, int n, void *data )
  *  Support: Craig Walther, {JAC}
 
 
- *- 
+ *-
 
  */
 
-void wvmOpt(float aMass, float tAmb, const float tSky[], float * waterDens, 
+void wvmOpt(float aMass, float tAmb, const float tSky[], float * waterDens,
              float * tau0, float * tWater, float * rms)
 {
   float waterDensErr;
@@ -208,7 +209,7 @@ void wvmOpt(float aMass, float tAmb, const float tSky[], float * waterDens,
       C
 
  *  Call:
- 
+
       wvmOptMulti(size_t n, const float aMass[], const float tAmb[],
              const float tSky[], float * waterDens,
              float * tau0, float * tWat, float *waterDensErr,
@@ -246,7 +247,7 @@ int wvmOptMulti(size_t n, const float aMass[], const float tAmb[], const float t
   wvmData data;
 
   const size_t m = 3;
-  int i;
+  size_t i;
 
   double params[3];   /* initial guesses */
   double tp[] = {19.9, 285., 0.25};  /* upper limits */
@@ -279,7 +280,7 @@ int wvmOptMulti(size_t n, const float aMass[], const float tAmb[], const float t
       return 0;
     }
 
-  /* make a first guess at the water density (assumes channel 3 is 
+  /* make a first guess at the water density (assumes channel 3 is
      optically thin) from the first measurement */
 
   *waterDens = (tSky[2] - 3.0)/29.0;
@@ -330,10 +331,10 @@ int wvmOptMulti(size_t n, const float aMass[], const float tAmb[], const float t
 void wvmEst(double aMass, double WA, double TWAT, double TAUO,
 	    double *TBRI, double *TTAU, double *TEFF, double *AEFF)
 {
-  /* Given the water vapour in the line of sight, the effective temperature 
-     of the water and the excess broadband opacity (e.g. due to clouds), 
-     calculates the expected (Rayleigh Jeans) brightness temperatures for 
-     the three channels of the radiometer plus the total opacity and the 
+  /* Given the water vapour in the line of sight, the effective temperature
+     of the water and the excess broadband opacity (e.g. due to clouds),
+     calculates the expected (Rayleigh Jeans) brightness temperatures for
+     the three channels of the radiometer plus the total opacity and the
      effective temperature of the water.
      Uses a simple 2-slab model but with coefficients adjusted to match ATM
   */
@@ -368,16 +369,16 @@ void wvmEst(double aMass, double WA, double TWAT, double TAUO,
 
       /* Effective temperature (includes effect of opacity, crudely) */
       temporary = -1. * TAUW/3.5;
-      TEFF[j] = TWAT - RJC - TOFF[j] 
+      TEFF[j] = TWAT - RJC - TOFF[j]
 	+ DELT[j]*(1. - exp(temporary));
 
       /* Radiative transfer */
-      temporary = -1. * TAUW-TAUO; 
+      temporary = -1. * TAUW-TAUO;
       ABSP = exp(temporary);
       TBRI[j] = TOUT*ABSP + TEFF[j]*(1.-ABSP);
 
-      /* Total opacity */ 
+      /* Total opacity */
       TTAU[j] = TAUW + TAUO + B[j] * aMass;
-      
+
     }
 }


### PR DESCRIPTION
This PR aims to remove the compiler warnings seen when the WVM code is compiled using gcc as part of smurf.